### PR TITLE
Update to work with lapack packaged in R version 4.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Likelihood for ANC Sentinel Surveillance Data
 Version: 0.3
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: This implements the random effects likelihood for ANC HIV prevalence described by Alkema, Raftery, Clark Ann Appl Stat 2007 (http://dx.doi.org/10.1214/07-AOAS111). This is implemented in the EPP model used by UNAIDS for generating HIV epidemic trends: http://www.unaids.org/en/dataanalysis/datatools/spectrumepp2013.
-Depends: R (>= 3.1.0)
+Depends: R (>= 4.3.0)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: anclik
 Title: Likelihood for ANC Sentinel Surveillance Data
-Version: 0.3
+Version: 0.4
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: This implements the random effects likelihood for ANC HIV prevalence described by Alkema, Raftery, Clark Ann Appl Stat 2007 (http://dx.doi.org/10.1214/07-AOAS111). This is implemented in the EPP model used by UNAIDS for generating HIV epidemic trends: http://www.unaids.org/en/dataanalysis/datatools/spectrumepp2013.
 Depends: R (>= 3.6.2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Likelihood for ANC Sentinel Surveillance Data
 Version: 0.3
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: This implements the random effects likelihood for ANC HIV prevalence described by Alkema, Raftery, Clark Ann Appl Stat 2007 (http://dx.doi.org/10.1214/07-AOAS111). This is implemented in the EPP model used by UNAIDS for generating HIV epidemic trends: http://www.unaids.org/en/dataanalysis/datatools/spectrumepp2013.
-Depends: R (>= 4.3.0)
+Depends: R (>= 3.6.2)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/src/anclikR.c
+++ b/src/anclikR.c
@@ -1,6 +1,6 @@
 /******************************************************************************************
  *
- *  Creates wrapper function to call anclik from R. Likelihood based on 
+ *  Creates wrapper function to call anclik from R. Likelihood based on
  *  Alkema, Raftery, Clark Ann Appl Stat 2007. (http://dx.doi.org/10.1214/07-AOAS111)
  *
  *  GPLv3, no warranty, etc...
@@ -71,7 +71,7 @@ SEXP anclikR(SEXP s_dst, SEXP s_vst, SEXP s_s2_pr_alpha, SEXP s_s2_pr_beta){
   int lenw = 4 * limit;
   int *iwork = (int *) R_alloc(limit, sizeof(int));
   double *work = (double *) R_alloc(lenw,  sizeof(double));
- 
+
   Rdqags(anclik_integrand, &param, &a, &b, &epsabs, &epsrel,
          REAL(s_val), &err, &neval, &ier, &limit, &lenw, &last, iwork, work);
 
@@ -90,9 +90,9 @@ double ldmvnorm(int n, double *x, double *mean, double *sigma){
   // x = x - mean
   for(int i=0; i<n; i++)
     x[i] = x[i] - mean[i];
-  
-  F77_NAME(dpotrf)("U", &n, sigma, &n, &info); // chol(sigma);
-  F77_NAME(dtrsv)("U", "T", "N", &n, sigma, &n, x, &inc); // inv(L) %*% (x-mean)
+
+  F77_NAME(dpotrf)("U", &n, sigma, &n, &info FCONE); // chol(sigma);
+  F77_NAME(dtrsv)("U", "T", "N", &n, sigma, &n, x, &inc FCONE FCONE FCONE); // inv(L) %*% (x-mean)
   double rss = F77_NAME(ddot)(&n, x, &inc, x, &inc); // (x-mean) %*% inv(sigma) %*% (x-mean)
 
   double logsqrtdet = 0.0;
@@ -102,7 +102,7 @@ double ldmvnorm(int n, double *x, double *mean, double *sigma){
   return -logsqrtdet - n*M_LN_SQRT_2PI - 0.5*rss;
 }
 
-// likelihood integrand 
+// likelihood integrand
 void anclik_integrand(double *val, int n, void * params){
 
   struct anclik_integrand_param *p = (struct anclik_integrand_param *) params;


### PR DESCRIPTION
Bit of a journey here, so since upgrade to R version 4.3.0 installing this package no longer works. From the [NEWS](https://cran.r-project.org/doc/manuals/r-release/NEWS.html) which includes

> * The included BLAS sources have been updated to those shipped with LAPACK version 3.10.1. (This caused some platform-dependent changes to package check output.) And then to the sources from LAPACK version 3.11.0 (with changes only to double complex subroutines).
> * The included LAPACK sources have been updated to include the four Fortran 90 routines rather than their Fortran 77 predecessors. This may give some different signs in SVDs or eigendecompositions.. (This completes the transition to LAPACK 3.10.x begun in R 4.2.0.)
> * The LAPACK sources have been updated to version 3.11.0. (No new subroutines have been added, so this almost entirely bug fixes: Those fixes do affect some computations with NaNs, including R's NA.)

And the signature for `F77_NAME(dpotrf)` and `F77_NAME(dtrsv)` has changed meaning we get compilation errors like

```
using C compiler: ‘gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0’
gcc -I"/usr/share/R/include" -DNDEBUG       -fpic  -g -O2 -ffile-prefix-map=/build/r-base-JhpCKt/r-base-4.3.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c anclikR.c -o anclikR.o
In file included from /usr/share/R/include/R.h:78,
                 from anclikR.c:13:
anclikR.c: In function ‘ldmvnorm’:
anclikR.c:94:12: error: too few arguments to function ‘dpotrf_’
   94 |   F77_NAME(dpotrf)("U", &n, sigma, &n, &info); // chol(sigma);
      |            ^~~~~~
/usr/share/R/include/R_ext/RS.h:77:25: note: in definition of macro ‘F77_CALL’
   77 | # define F77_CALL(x)    x ## _
      |                         ^
anclikR.c:94:3: note: in expansion of macro ‘F77_NAME’
   94 |   F77_NAME(dpotrf)("U", &n, sigma, &n, &info); // chol(sigma);
      |   ^~~~~~~~
/usr/share/R/include/R_ext/Lapack.h:825:10: note: declared here
  825 | F77_NAME(dpotrf)(const char* uplo, const int* n,
      |          ^~~~~~
/usr/share/R/include/R_ext/RS.h:77:25: note: in definition of macro ‘F77_CALL’
   77 | # define F77_CALL(x)    x ## _
      |                         ^
/usr/share/R/include/R_ext/Lapack.h:825:1: note: in expansion of macro ‘F77_NAME’
  825 | F77_NAME(dpotrf)(const char* uplo, const int* n,
      | ^~~~~~~~
anclikR.c:95:12: error: too few arguments to function ‘dtrsv_’
   95 |   F77_NAME(dtrsv)("U", "T", "N", &n, sigma, &n, x, &inc); // inv(L) %*% (x-mean)
      |            ^~~~~
/usr/share/R/include/R_ext/RS.h:77:25: note: in definition of macro ‘F77_CALL’
   77 | # define F77_CALL(x)    x ## _
      |                         ^
anclikR.c:95:3: note: in expansion of macro ‘F77_NAME’
   95 |   F77_NAME(dtrsv)("U", "T", "N", &n, sigma, &n, x, &inc); // inv(L) %*% (x-mean)
      |   ^~~~~~~~
/usr/share/R/include/R_ext/BLAS.h:169:10: note: declared here
  169 | F77_NAME(dtrsv)(const char *uplo, const char *trans,
      |          ^~~~~
/usr/share/R/include/R_ext/RS.h:77:25: note: in definition of macro ‘F77_CALL’
   77 | # define F77_CALL(x)    x ## _
      |                         ^
/usr/share/R/include/R_ext/BLAS.h:169:1: note: in expansion of macro ‘F77_NAME’
  169 | F77_NAME(dtrsv)(const char *uplo, const char *trans,
      | ^~~~~~~~
make: *** [/usr/lib/R/etc/Makeconf:191: anclikR.o] Error 1
ERROR: compilation failed for package ‘anclik’
* removing ‘/home/rashton/R/x86_64-pc-linux-gnu-library/4.3/anclik’
```

Digging around it looks like fortran strings now also require their size specified, this is available via macro FCONE see https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Fortran-character-strings so I think this should sort compilation issues on R > 4.3.0. Added a requirement on R 3.6.2 as that was when support was added.